### PR TITLE
Remove offsets from the Frame struct

### DIFF
--- a/src/drawing.rs
+++ b/src/drawing.rs
@@ -6,8 +6,6 @@ use std::io::{self, Read};
 
 pub struct Frame {
     pub buffer: Vec<u8>,
-    xoffset: Option<u32>,
-    yoffset: Option<u32>,
     width: u32,
     height: u32,
     bytes_per_pixel: u32,
@@ -15,60 +13,43 @@ pub struct Frame {
 
 impl Frame {
     pub fn new(fb: &Framebuffer) -> Self {
-        let xoffset = None;
-        let yoffset = None;
         let width = fb.fix_screen_info.line_length;
         let height = fb.var_screen_info.yres;
         let bytes_per_pixel = fb.var_screen_info.bits_per_pixel / 8;
 
         Self {
             buffer: vec![0u8; (width * height) as usize],
-            xoffset,
-            yoffset,
             width,
             height,
             bytes_per_pixel,
         }
     }
 
-    pub fn draw_image(&mut self, path: &str) {
+    fn draw_any_image(&mut self, path: &str, xoffset: Option<u32>, yoffset: Option<u32>) {
         let img = bmp::open(path).unwrap();
-        let xoffset = self
-            .xoffset
-            .unwrap_or((self.width / self.bytes_per_pixel) / 2 - img.get_width() / 2);
-        let yoffset = self
-            .yoffset
-            .unwrap_or(self.height / 2 - img.get_height() / 2);
+        let xof = xoffset.unwrap_or((self.width / self.bytes_per_pixel) / 2 - img.get_width() / 2);
+        let yof = yoffset.unwrap_or(self.height / 2 - img.get_height() / 2);
 
         for (x, y) in img.coordinates() {
             let px = img.get_pixel(x, y);
-            let xb = (x + xoffset) * self.bytes_per_pixel;
-            let yb = (y + yoffset) * self.width;
+            let xb = (x + xof) * self.bytes_per_pixel;
+            let yb = (y + yof) * self.width;
             let idx = (xb + yb) as usize;
             self.buffer[idx] = px.b;
             self.buffer[idx + 1] = px.g;
             self.buffer[idx + 2] = px.r;
         }
     }
-}
 
-pub fn frame_from_bgrt(fb: &Framebuffer) -> Frame {
+    pub fn draw_image(&mut self, path: &str) {
+        self.draw_any_image(path, None, None);
+    }
+
+    pub fn draw_bgrt_image(&mut self) {
         let xoffset = read_u32_from_file("/sys/firmware/acpi/bgrt/xoffset").ok();
         let yoffset = read_u32_from_file("/sys/firmware/acpi/bgrt/yoffset").ok();
-        let width = fb.fix_screen_info.line_length;
-        let height = fb.var_screen_info.yres;
-        let bytes_per_pixel = fb.var_screen_info.bits_per_pixel / 8;
-
-        let mut frame = Frame {
-            buffer: vec![0u8; (width * height) as usize],
-            xoffset,
-            yoffset,
-            width,
-            height,
-            bytes_per_pixel,
-        };
-        frame.draw_image("/sys/firmware/acpi/bgrt/image");
-        frame
+        self.draw_any_image("/sys/firmware/acpi/bgrt/image", xoffset, yoffset);
+    }
 }
 
 fn read_u32_from_file(fname: &str) -> io::Result<u32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
+mod cli;
 mod drawing;
 mod passwd;
-mod cli;
 
 use crate::drawing::Frame;
 use framebuffer::{Framebuffer, KdMode};
@@ -8,22 +8,17 @@ use std::env;
 use std::fs::File;
 use std::io::{self, Write};
 
-
 fn main() -> io::Result<()> {
     let args: Vec<String> = env::args().collect();
     let config = cli::parse_args(&args).unwrap();
 
     let mut framebuffer = Framebuffer::new("/dev/fb0").unwrap();
-    let frame = match config.image_path {
-        None => {
-            drawing::frame_from_bgrt(&framebuffer)
-        }
-        Some(img_fname) => {
-            let mut frame = Frame::new(&framebuffer);
-            frame.draw_image(&img_fname);
-            frame
-        }
-    };
+    let mut frame = Frame::new(&framebuffer);
+
+    match config.image_path {
+        Some(fname) => frame.draw_image(&fname),
+        None => frame.draw_bgrt_image(),
+    }
     framebuffer.write_frame(frame.buffer.as_slice());
 
     let feedback = || {};


### PR DESCRIPTION
Add a function to the Frame struct that draws the bgrt image by reading
the offsets and image from standard firmware paths.